### PR TITLE
fix addCredit to not add the message author

### DIFF
--- a/SpriteBot.py
+++ b/SpriteBot.py
@@ -1652,7 +1652,7 @@ class SpriteBot:
         base_file, base_name = SpriteUtils.getLinkData(base_link)
 
         # stage a post in submissions
-        await self.postStagedSubmission(submit_channel, "--addauthor", full_idx, chosen_node, asset_type, author,
+        await self.postStagedSubmission(submit_channel, "--addauthor", full_idx, chosen_node, asset_type, author + "/" + wanted_author,
                                                 False, None, base_file, base_name, None)
 
 


### PR DESCRIPTION
The addportraitcredit command added the message author in the credit instead of the mentionned person (should also apply to addspritecredit). Fix this.